### PR TITLE
:recycle: Drop support for ruby 1.9/2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.9
-  - 2.0
   - 2.1
   - 2.2
 before_install:

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in compare_linker_wrapper.gemspec
 gemspec
 
-gem 'byebug' if RUBY_VERSION >= '2.0.0'
+gem 'byebug'
 gem 'pry'


### PR DESCRIPTION
Both are `End of Life`.